### PR TITLE
Update repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://golem.cloud"
+repository = "https://github.com/golemcloud/golem-wit"
 description = "WIT definitions and WASI adapter modules for Golem"
 
 [lib]


### PR DESCRIPTION
Update [repository](https://rust-digger.code-maven.com/about-repository) field in `Cargo.toml` to point to the GitHub repo.

This makes the location of the source code show correctly on Crates.io. 🙂