### PR TITLE
Add handle type to wasm-rpc

### DIFF
--- a/wit/deps/wasm-rpc/wasm-rpc.wit
+++ b/wit/deps/wasm-rpc/wasm-rpc.wit
@@ -29,6 +29,7 @@ interface types {
     prim-char(char),
     prim-bool(bool),
     prim-string(string),
+    handle(tuple<uri, u64>)
   }
 
   record uri {


### PR DESCRIPTION
Keeps it in sync with [wasm-rpc](https://github.com/golemcloud/wasm-rpc) 